### PR TITLE
Updates services to allow for providing start and end date args to Matomo API

### DIFF
--- a/modules/islandora_matomo_blocks/src/Plugin/Block/IslandoraNodeAllMediaDownloadsBlock.php
+++ b/modules/islandora_matomo_blocks/src/Plugin/Block/IslandoraNodeAllMediaDownloadsBlock.php
@@ -26,7 +26,7 @@ class IslandoraNodeAllMediaDownloadsBlock extends BlockBase {
 
       // Get views for node
       $node = \Drupal::routeMatch()->getParameter('node'); 
-      $views = \Drupal::service('islandora_matomo.default')->getViewsForNode($node->id());
+      $views = \Drupal::service('islandora_matomo.default')->getViewsForNode(['nid' => $node->id()]);
       $mids = \Drupal::entityQuery('media')
         ->condition('field_media_of', $node->id())
         ->execute();
@@ -35,7 +35,7 @@ class IslandoraNodeAllMediaDownloadsBlock extends BlockBase {
         $media = Media::load($mid);
         $fid = \Drupal::service('islandora_matomo.default')->getFileFromMedia($mid);
         $media_data[$mid]['label'] = $media->label();
-        $media_data[$mid]['downloads'] = \Drupal::service('islandora_matomo.default')->getDownloadsForFile($fid);
+        $media_data[$mid]['downloads'] = \Drupal::service('islandora_matomo.default')->getDownloadsForFile(['fid' => $fid]);
       }
       $content = "<div id='islandora-node-all-media-download-block-wrapper' class='islandora-node-all-media-download-block'>";
       $content .= "<span id='islandora-node-all-media-download-block-views' class='islandora-node-all-media-download-block'>Views for '{$node->label()}': {$views}</span><br/>";

--- a/modules/islandora_matomo_blocks/src/Plugin/Block/IslandoraNodeViewsAndOriginalFileSummedDownloadsBlock.php
+++ b/modules/islandora_matomo_blocks/src/Plugin/Block/IslandoraNodeViewsAndOriginalFileSummedDownloadsBlock.php
@@ -26,7 +26,7 @@ class IslandoraNodeViewsAndOriginalFileSummedDownloadsBlock extends BlockBase {
 
       // Get views for node
       $node = \Drupal::routeMatch()->getParameter('node'); 
-      $views = \Drupal::service('islandora_matomo.default')->getViewsForNode($node->id());
+      $views = \Drupal::service('islandora_matomo.default')->getViewsForNode(['nid' => $node->id()]);
       
       // Get downloads for Original File media of node
       $original_file_tid = key(\Drupal::entityTypeManager()
@@ -41,7 +41,7 @@ class IslandoraNodeViewsAndOriginalFileSummedDownloadsBlock extends BlockBase {
         $fid = \Drupal::service('islandora_matomo.default')->getFileFromMedia($mid);
         $fids[] = $fid;
       }
-      $downloads = \Drupal::service('islandora_matomo.default')->getSummedDownloadsForFiles($fids);
+      $downloads = \Drupal::service('islandora_matomo.default')->getSummedDownloadsForFiles(['fids' => $fids]);
       $content = <<<EOS
 <div id='islandora-node-and-original-files-download-block-wrapper' class='islandora-node-and-original-files-download-block'>
   <span id='islandora-node-and-original-files-download-block-views' class='islandora-node-and-original-files-download-block'>Views: {$views}</span><br/>

--- a/modules/islandora_matomo_blocks/src/Plugin/Block/IslandoraNodeViewsBlock.php
+++ b/modules/islandora_matomo_blocks/src/Plugin/Block/IslandoraNodeViewsBlock.php
@@ -22,7 +22,7 @@ class IslandoraNodeViewsBlock extends BlockBase {
   public function build() {
     if (\Drupal::routeMatch()->getRouteName() == 'entity.node.canonical') {
       $node = \Drupal::routeMatch()->getParameter('node'); 
-      $views = \Drupal::service('islandora_matomo.default')->getViewsForNode($node->id());
+      $views = \Drupal::service('islandora_matomo.default')->getViewsForNode(['nid' => $node->id()]);
       $content = <<<EOS
 <div id='islandora-node-views-block-wrapper' class='islandora-node-views-block'>
   <span id='islandora-node-views-block-views' class='islandora-node-views-block'>Views: {$views}</span>

--- a/src/IslandoraMatomoService.php
+++ b/src/IslandoraMatomoService.php
@@ -62,8 +62,8 @@ class IslandoraMatomoService implements IslandoraMatomoServiceInterface {
       return NULL;
     }
     else {
-      $date_range_start = (array_key_exists($params['start_date'] ? $params['start_date'] : '2000-01-01'));
-      $date_range_end = (array_key_exists($params['end_date'] ? $params['end_date'] : date('Y-m-d', time())));
+      $date_range_start = (array_key_exists('start_date', $params) ? $params['start_date'] : '2000-01-01');
+      $date_range_end = (array_key_exists('end_date', $params) ? $params['end_date'] : date('Y-m-d', time()));
       $date_range = "{$date_range_start},{$date_range_end}";
       $result = 0;
       switch ($params['mode']) :
@@ -129,7 +129,7 @@ class IslandoraMatomoService implements IslandoraMatomoServiceInterface {
     $file_uri = $file->getFileUri();
     $params['url'] = file_create_url($file_uri);
     $params['mode'] = 'downloads';
-    $downloads = \Drupal::service('islandora_matomo.default')->queryMatomoApi($file_url, 'downloads');
+    $downloads = \Drupal::service('islandora_matomo.default')->queryMatomoApi($params);
     return $downloads;
   }
 

--- a/src/IslandoraMatomoService.php
+++ b/src/IslandoraMatomoService.php
@@ -46,7 +46,7 @@ class IslandoraMatomoService implements IslandoraMatomoServiceInterface {
    *
    * @param array $params
    *  Array that must include $params['url'], the URL to be queried, and $params['mode'] as 'views' or 'downloads'.
-   *  May optionally include  $parms['start_date'] and/or $params['end_date'] if a range is desired.
+   *  May optionally include  $params['start_date'] and/or $params['end_date'] if a range is desired.
    */
   public function queryMatomoApi(array $params) {
     $url = rtrim($params['url'], '/');
@@ -111,7 +111,7 @@ class IslandoraMatomoService implements IslandoraMatomoServiceInterface {
    *
    * @param array $params
    *  Array that must include $params['nid'], the node ID of the node to be queried.
-   *  May optionally include  $parms['start_date'] and/or $params['end_date'] if a range is desired.
+   *  May optionally include  $params['start_date'] and/or $params['end_date'] if a range is desired.
    */
   public function getViewsForNode(array $params) {
     $node = Node::load($params['nid']);
@@ -126,7 +126,7 @@ class IslandoraMatomoService implements IslandoraMatomoServiceInterface {
    *
    * @param array $params
    *  Array that must include $params['fid'], the file entity ID of the file to be queried.
-   *  May optionally include  $parms['start_date'] and/or $params['end_date'] if a range is desired.
+   *  May optionally include  $params['start_date'] and/or $params['end_date'] if a range is desired.
    */
   public function getDownloadsForFile(array $params) {
     $file = File::load($params['fid']);
@@ -142,7 +142,7 @@ class IslandoraMatomoService implements IslandoraMatomoServiceInterface {
    *
    * @param array $params
    *  Array that must include $params['fids'], an array of file entity IDs of the files to be queried.
-   *  May optionally include  $parms['start_date'] and/or $params['end_date'] if a range is desired.
+   *  May optionally include  $params['start_date'] and/or $params['end_date'] if a range is desired.
    */
   public function getSummedDownloadsForFiles(array $params) {
     $sum = 0;

--- a/src/IslandoraMatomoService.php
+++ b/src/IslandoraMatomoService.php
@@ -110,7 +110,7 @@ class IslandoraMatomoService implements IslandoraMatomoServiceInterface {
    * Get views for node.
    *
    * @param array $params
-   *  Array that must include $params['nid'], the node ID of the object to be queried.
+   *  Array that must include $params['nid'], the node ID of the node to be queried.
    *  May optionally include  $parms['start_date'] and/or $params['end_date'] if a range is desired.
    */
   public function getViewsForNode(array $params) {
@@ -123,6 +123,10 @@ class IslandoraMatomoService implements IslandoraMatomoServiceInterface {
 
   /**
    * Get download counts for single file.
+   *
+   * @param array $params
+   *  Array that must include $params['fid'], the file entity ID of the file to be queried.
+   *  May optionally include  $parms['start_date'] and/or $params['end_date'] if a range is desired.
    */
   public function getDownloadsForFile(array $params) {
     $file = File::load($params['fid']);
@@ -135,6 +139,10 @@ class IslandoraMatomoService implements IslandoraMatomoServiceInterface {
 
   /**
    * Calculate sum of downloads.
+   *
+   * @param array $params
+   *  Array that must include $params['fids'], an array of file entity IDs of the files to be queried.
+   *  May optionally include  $parms['start_date'] and/or $params['end_date'] if a range is desired.
    */
   public function getSummedDownloadsForFiles(array $params) {
     $sum = 0;
@@ -148,7 +156,10 @@ class IslandoraMatomoService implements IslandoraMatomoServiceInterface {
   }
 
   /**
-   * Get files from media.
+   * Get file-containing field from arbitrary Islandora media entities.
+   *
+   * @param int $mid
+   * An integer representing a media entity ID 
    */
   public function getFileFromMedia($mid) {
     $media_file_fields = [

--- a/src/IslandoraMatomoServiceInterface.php
+++ b/src/IslandoraMatomoServiceInterface.php
@@ -7,10 +7,10 @@ namespace Drupal\islandora_matomo;
  */
 interface IslandoraMatomoServiceInterface {
 
-  public function queryMatomoApi($url, $mode);
-  public function getViewsForNode($nid);
-  public function getDownloadsForFile($fid);
-  public function getSummedDownloadsForFiles($fids);
+  public function queryMatomoApi(array $params);
+  public function getViewsForNode(array $params);
+  public function getDownloadsForFile(array $params);
+  public function getSummedDownloadsForFiles(array $params);
   public function getFileFromMedia($mid);
 
 }


### PR DESCRIPTION
This PR changes the services arguments to an array that may or may not include 'start_date' and 'end_date' keys. If the keys are absent, a default start date of '2000-01-01' and a default end date of the current day are provided. This has been tested with Islandora Playbook.

Note that all calls to the services from other services and from the blocks have been updated to use this new array parameter format as well.

The core of the PR is really about the ability to provide custom date ranges to the Matomo API calls, if you know of a better way to format the arguments feel free to get rid of my way of doing it. I'm a n00b when it comes to doing things the "right" way in Drupal 8.