### PR TITLE
Matomo multimedia events 195

### DIFF
--- a/islandora_matomo.libraries.yml
+++ b/islandora_matomo.libraries.yml
@@ -1,0 +1,10 @@
+# islandora_matomo.libraries.yml
+track:
+  version: 1.x
+  header: true
+  js:
+    js/islandora_matomo.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
+    - core/drupal.dialog.ajax #Required for dialogs

--- a/islandora_matomo.libraries.yml
+++ b/islandora_matomo.libraries.yml
@@ -6,5 +6,6 @@ track:
     js/islandora_matomo.js: {}
   dependencies:
     - core/jquery
+    - core/jquery.once
     - core/drupal
     - core/drupal.dialog.ajax #Required for dialogs

--- a/islandora_matomo.module
+++ b/islandora_matomo.module
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Contains islandora_matomo.module.
+ */
+
+function islandora_matomo_preprocess_node(array &$variables) {
+  \Drupal::logger('islandora_matomo')->info(t("Node view mode @mode.", ['@mode' => $variables['view_mode']]));
+  if (!$variables["teaser"]) {
+    $islandora_utils = \Drupal::service('islandora.utils');
+    $servicefile_term = $islandora_utils->getTermForUri('http://pcdm.org/use#ServiceFile');
+    $servicefile = $islandora_utils->getMediaWithTerm($variables['node'], $servicefile_term);
+    if (is_object($servicefile) && ($servicefile->bundle() == 'video' ||
+      $servicefile->bundle() == 'remote_video' || $servicefile->bundle() == 'audio')) {
+      \Drupal::logger('islandora_matomo')->info(t("Service file media @bundle.", ['@bundle' => $servicefile->bundle()]));
+      $variables['#attached']['library'] = 'islandora_matomo/track';
+    }
+  }
+}

--- a/islandora_matomo.module
+++ b/islandora_matomo.module
@@ -12,7 +12,7 @@ function islandora_matomo_preprocess_node(array &$variables) {
     $servicefile_term = $islandora_utils->getTermForUri('http://pcdm.org/use#ServiceFile');
     $servicefile = $islandora_utils->getMediaWithTerm($variables['node'], $servicefile_term);
     if (is_object($servicefile) && ($servicefile->bundle() == 'video' ||
-      $servicefile->bundle() == 'remote_video' || $servicefile->bundle() == 'audio')) {
+      $servicefile->bundle() == 'audio')) {
       \Drupal::logger('islandora_matomo')->info(t("Service file media @bundle.", ['@bundle' => $servicefile->bundle()]));
       $variables['#attached']['library'] = 'islandora_matomo/track';
     }

--- a/js/islandora_matomo.js
+++ b/js/islandora_matomo.js
@@ -1,0 +1,20 @@
+/**
+ * @file - islandora_matomo.js
+ */
+
+(function ($) {
+Drupal.behaviors.islandora_matomo = {
+  attach: function (context, settings) {
+    
+    var video = document.getElementsByTagName('video')[0];
+    if (video) {        
+      video.addEventListener('play', (event) => {
+        console.log('video found on page');
+        console.log('The Boolean paused property is now false. Either the ' +
+        'play() method was called or the autoplay attribute was toggled.');
+      }, {once: true});
+    }
+  }
+};
+
+})(jQuery, Drupal);

--- a/js/islandora_matomo.js
+++ b/js/islandora_matomo.js
@@ -5,21 +5,30 @@
 (function ($) {
 Drupal.behaviors.islandora_matomo = {
   attach: function (context, settings) {
-    $('audio').each( function() {
-        console.log("hello world of audio");
-        $(this, context).once('islandora_matomo').on("play", function() {
-          console.log("only fires once per play");
-        });
-    });
-    $('video').each( function() {
-        console.log("hello world of video");
-        console.log('video found on page');
-        $(this, context).once('islandora_matomo').on("play", function() {
-          console.log("only fires once per play");
-          console.log('The Boolean paused property is now false. Either the ' +
-            'play() method was called or the autoplay attribute was toggled.');
-        });
-    });
+    // Since any of these would require the _paq library is defined -- and that
+    // depends on whether or not the user is configured to track Matomo events
+    // i.e. "do not add tracking for Admin role", this logic can wrap any
+    // further logic.
+    if (typeof _paq !== 'undefined') {
+      var pathname = window.location.pathname;
+      console.log("path = " + pathname);
+      pathname = pathname.substring(1, pathname.length);
+      console.log("path = " + pathname);
+      $('audio').each( function() {
+          $(this, context).once('islandora_matomo').on("play", function() {
+            // Track the event with Matomo.
+            _paq.push(['trackEvent', 'MediaEvents', 'Play audio', pathname]);
+            console.log("only fires once per play");
+          });
+      });
+      $('video').each( function() {
+          $(this, context).once('islandora_matomo').on("play", function() {
+            // Track the event with Matomo.
+            _paq.push(['trackEvent', 'MediaEvents', 'Play video', pathname]);
+            console.log("only fires once per play");
+          });
+      });
+    }
   }
 };
 

--- a/js/islandora_matomo.js
+++ b/js/islandora_matomo.js
@@ -5,15 +5,21 @@
 (function ($) {
 Drupal.behaviors.islandora_matomo = {
   attach: function (context, settings) {
-    
-    var video = document.getElementsByTagName('video')[0];
-    if (video) {        
-      video.addEventListener('play', (event) => {
+    $('audio').each( function() {
+        console.log("hello world of audio");
+        $(this, context).once('islandora_matomo').on("play", function() {
+          console.log("only fires once per play");
+        });
+    });
+    $('video').each( function() {
+        console.log("hello world of video");
         console.log('video found on page');
-        console.log('The Boolean paused property is now false. Either the ' +
-        'play() method was called or the autoplay attribute was toggled.');
-      }, {once: true});
-    }
+        $(this, context).once('islandora_matomo').on("play", function() {
+          console.log("only fires once per play");
+          console.log('The Boolean paused property is now false. Either the ' +
+            'play() method was called or the autoplay attribute was toggled.');
+        });
+    });
   }
 };
 


### PR DESCRIPTION
@elizoller -- since I coded this, would you test the PR?

This change only adds a bit of javascript to the islandora_matomo module and there are no configuration changes.

To test this:
1. pull in the updated code and clear the cache
2. navigate to items that are audio and video while you are not logged in as Admin (since Matomo is set to not track the role Admin actions), click play.
3. after the data has been synch'd with Matomo, the play events should be visible in Matomo for the given period in the Behavior | Events section. The "Event Category" for either audio / video are "MediaEvents". The separate "Event Actions" are either "Play audio" or "Play video" -- and those actions will have values that correspond to the audio/video item url such as "items/123" along with the corresponding number of "plays" (events) for that item on the time period.

Please let me know if you have any questions / clarifications / suggestions.